### PR TITLE
Implement ride service and history view

### DIFF
--- a/src/app/core/services/ride.service.ts
+++ b/src/app/core/services/ride.service.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface RideLocation {
+  lat: number;
+  lng: number;
+  address: string;
+  placeId?: string;
+}
+
+export interface Ride {
+  id: number;
+  pickupLocation: RideLocation;
+  dropoffLocation: RideLocation;
+  scheduledTime: string;
+  vehicleType: string;
+  passengerCount: number;
+  specialRequirements?: string;
+  emergencyContact?: string;
+  paymentMethod: string;
+  status: string;
+}
+
+export interface RideBookingRequest {
+  pickupLocation: RideLocation;
+  dropoffLocation: RideLocation;
+  scheduledTime: string;
+  vehicleType: string;
+  passengerCount: number;
+  specialRequirements?: string;
+  emergencyContact?: string;
+  paymentMethod: string;
+  estimatedFare: number;
+  route?: any;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RideService {
+  private apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  createRide(data: RideBookingRequest): Observable<Ride> {
+    return this.http.post<Ride>(`${this.apiUrl}/rides`, data);
+  }
+
+  getUserRides(): Observable<Ride[]> {
+    return this.http.get<Ride[]>(`${this.apiUrl}/rides`);
+  }
+
+  getRideById(id: number): Observable<Ride> {
+    return this.http.get<Ride>(`${this.apiUrl}/rides/${id}`);
+  }
+}

--- a/src/app/pages/rides/book-ride/book-ride.page.ts
+++ b/src/app/pages/rides/book-ride/book-ride.page.ts
@@ -37,6 +37,7 @@ import {
   AlertController,
   ToastController
 } from '@ionic/angular/standalone';
+import { firstValueFrom } from 'rxjs';
 import { addIcons } from 'ionicons';
 import {
   locationOutline,
@@ -57,6 +58,7 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { MapsService, Location, RouteInfo } from '../../../core/services/maps.service';
 import { MapsMockService } from '../../../core/services/maps-mock.service';
 import { AuthService, User } from '../../../core/services/auth.service';
+import { RideService } from '../../../core/services/ride.service';
 import { environment } from '../../../../environments/environment';
 
 export interface VehicleOption {
@@ -199,6 +201,7 @@ export class BookRidePage implements OnInit, AfterViewInit, OnDestroy {
     private mapsService: MapsService,
     private mapsMockService: MapsMockService,
     private authService: AuthService,
+    private rideService: RideService,
     private router: Router,
     private loadingController: LoadingController,
     private alertController: AlertController,
@@ -449,11 +452,8 @@ export class BookRidePage implements OnInit, AfterViewInit, OnDestroy {
         route: this.routeInfo || undefined
       };
 
-      // TODO: Call booking API
-      console.log('Booking data:', bookingData);
-
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      const ride = await firstValueFrom(this.rideService.createRide(bookingData));
+      console.log('Ride created:', ride);
 
       await loading.dismiss();
 

--- a/src/app/pages/rides/ride-history/ride-history.page.html
+++ b/src/app/pages/rides/ride-history/ride-history.page.html
@@ -1,2 +1,26 @@
-<ion-header><ion-toolbar color="primary"><ion-title>Ride History</ion-title></ion-toolbar></ion-header>
-<ion-content><div style="padding: 1rem;"><ion-card><ion-card-header><ion-card-title>Your Ride History</ion-card-title></ion-card-header><ion-card-content>Ride history features coming soon!</ion-card-content></ion-card></div></ion-content>
+<ion-header>
+  <ion-toolbar color="primary">
+    <ion-title>Ride History</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-list *ngIf="rides.length > 0">
+    <ion-item button *ngFor="let ride of rides" (click)="viewRide(ride.id)">
+      <ion-label>
+        <h3>{{ ride.pickupLocation.address }} → {{ ride.dropoffLocation.address }}</h3>
+        <p>{{ ride.scheduledTime | date:'short' }}</p>
+      </ion-label>
+      <ion-badge slot="end" [color]="getStatusColor(ride.status)">{{ ride.status }}</ion-badge>
+    </ion-item>
+  </ion-list>
+
+  <ion-card *ngIf="rides.length === 0" class="empty-card">
+    <ion-card-header>
+      <ion-card-title>No rides found</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      You have not booked any rides yet.
+    </ion-card-content>
+  </ion-card>
+</ion-content>

--- a/src/app/pages/rides/ride-history/ride-history.page.scss
+++ b/src/app/pages/rides/ride-history/ride-history.page.scss
@@ -1,1 +1,3 @@
-// Placeholder styles
+.empty-card {
+  margin: 1rem;
+}

--- a/src/app/pages/rides/ride-history/ride-history.page.ts
+++ b/src/app/pages/rides/ride-history/ride-history.page.ts
@@ -1,15 +1,75 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { IonContent, IonHeader, IonTitle, IonToolbar, IonCard, IonCardHeader, IonCardTitle, IonCardContent } from '@ionic/angular/standalone';
+import { Router } from '@angular/router';
+import {
+  IonContent,
+  IonHeader,
+  IonTitle,
+  IonToolbar,
+  IonCard,
+  IonCardHeader,
+  IonCardTitle,
+  IonCardContent,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonBadge
+} from '@ionic/angular/standalone';
+import { firstValueFrom } from 'rxjs';
+import { RideService, Ride } from '../../../core/services/ride.service';
 
 @Component({
   selector: 'app-ride-history',
   templateUrl: './ride-history.page.html',
   styleUrls: ['./ride-history.page.scss'],
   standalone: true,
-  imports: [CommonModule, IonContent, IonHeader, IonTitle, IonToolbar, IonCard, IonCardHeader, IonCardTitle, IonCardContent],
+  imports: [
+    CommonModule,
+    IonContent,
+    IonHeader,
+    IonTitle,
+    IonToolbar,
+    IonCard,
+    IonCardHeader,
+    IonCardTitle,
+    IonCardContent,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonBadge
+  ],
 })
 export class RideHistoryPage implements OnInit {
-  constructor() {}
-  ngOnInit() {}
+  rides: Ride[] = [];
+
+  constructor(private rideService: RideService, private router: Router) {}
+
+  ngOnInit() {
+    this.loadRides();
+  }
+
+  async loadRides() {
+    try {
+      this.rides = await firstValueFrom(this.rideService.getUserRides());
+    } catch (error) {
+      console.error('Failed to load rides', error);
+    }
+  }
+
+  viewRide(id: number) {
+    this.router.navigate(['/rides/details', id]);
+  }
+
+  getStatusColor(status: string): string {
+    switch (status) {
+      case 'completed':
+        return 'success';
+      case 'pending':
+        return 'warning';
+      case 'canceled':
+        return 'danger';
+      default:
+        return 'primary';
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- create `RideService` for API integration
- use `RideService` in booking flow
- implement ride history page with dynamic data

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d207e5d88327a928e9ccba9c693e